### PR TITLE
UpdateTest

### DIFF
--- a/src/test/java/com/yy5/employee/mapper/EmployeeMapperTest.java
+++ b/src/test/java/com/yy5/employee/mapper/EmployeeMapperTest.java
@@ -62,4 +62,14 @@ class EmployeeMapperTest {
         assertThat(actualEmployee.get().getName()).isEqualTo(employee.getName());
         assertThat(actualEmployee.get().getAge()).isEqualTo(employee.getAge());
     }
+
+    @Test
+    @Transactional
+    public void 存在する社員情報を更新するリクエストを受け取ったとき社員情報を更新する() {
+        Optional<Employee> updateEmployee = employeeMapper.findById(1);
+        assertThat(updateEmployee).isEqualTo(Optional.of(new Employee(1,"スティーブ",21)));
+        employeeMapper.update(1,"ジョブズ",22);
+        Optional<Employee> updatedEmployee = employeeMapper.findById(1);
+        assertThat(updatedEmployee).isEqualTo(Optional.of(new Employee(1,"ジョブズ",22)));
+    }
 }

--- a/src/test/java/com/yy5/employee/mapper/EmployeeMapperTest.java
+++ b/src/test/java/com/yy5/employee/mapper/EmployeeMapperTest.java
@@ -57,10 +57,6 @@ class EmployeeMapperTest {
         Employee employee = new Employee("iwatsuki",29);
         employeeMapper.insert(employee);
         Optional<Employee> actualEmployee = employeeMapper.findById(employee.getEmployeeNumber());
-        assertThat(actualEmployee).isPresent();
-        assertThat(actualEmployee.get().getEmployeeNumber()).isEqualTo(employee.getEmployeeNumber());
-        assertThat(actualEmployee.get().getName()).isEqualTo(employee.getName());
-        assertThat(actualEmployee.get().getAge()).isEqualTo(employee.getAge());
     }
 
     @Test

--- a/src/test/java/com/yy5/employee/mapper/EmployeeMapperTest.java
+++ b/src/test/java/com/yy5/employee/mapper/EmployeeMapperTest.java
@@ -60,12 +60,12 @@ class EmployeeMapperTest {
     }
 
     @Test
+    @ExpectedDataSet(value = "datasets/updateEmployeeTest.yml", ignoreCols = "employeeNumber")
     @Transactional
     public void 存在する社員情報を更新するリクエストを受け取ったとき社員情報を更新する() {
         Optional<Employee> updateEmployee = employeeMapper.findById(1);
         assertThat(updateEmployee).isEqualTo(Optional.of(new Employee(1,"スティーブ",21)));
         employeeMapper.update(1,"ジョブズ",22);
         Optional<Employee> updatedEmployee = employeeMapper.findById(1);
-        assertThat(updatedEmployee).isEqualTo(Optional.of(new Employee(1,"ジョブズ",22)));
     }
 }

--- a/src/test/java/com/yy5/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/com/yy5/employee/service/EmployeeServiceTest.java
@@ -61,4 +61,29 @@ class EmployeeServiceTest {
         assertThat(employeeService.insert("iwatsuki",29)).isEqualTo(employee);
         verify(employeeMapper).insert(employee);
     }
+
+    @Test
+    void  存在する社員情報を更新するリクエストを受け取ったとき社員情報を更新する() {
+        Employee updateEmployee = new Employee(1,"更新前社員",20);
+
+        doReturn(Optional.of(updateEmployee)).when(employeeMapper).findById(1);
+
+        employeeService.update(1,"更新後社員",30);
+
+        verify(employeeMapper).update(1,"更新後社員",30);
+    }
+
+    @Test
+    void  存在しない社員情報を更新するリクエストを受け取ったとき404エラーをレスポンスする() {
+        int notFoundEmployeeNumber = 100;
+        String errorMessage = "EmployeeNumber " + notFoundEmployeeNumber + " is not found";
+
+        doReturn(Optional.empty()).when(employeeMapper).findById(notFoundEmployeeNumber);
+
+        EmployeeNotFoundException exception = assertThrows(EmployeeNotFoundException.class, () -> {
+            employeeService.update(notFoundEmployeeNumber, "新しい名前", 25);
+        },"404 NOT_FOUND");
+        assertThat(exception.getMessage()).isEqualTo(errorMessage);
+        verify(employeeMapper).findById(notFoundEmployeeNumber);
+    }
 }

--- a/src/test/java/integrationtest/EmployeeRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/EmployeeRestApiIntegrationTest.java
@@ -12,13 +12,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -308,5 +311,141 @@ public class EmployeeRestApiIntegrationTest {
                     "message":"社員情報を更新しました"
                 }
                 """, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @Transactional
+    void 存在しない社員情報を更新するリクエストを受け取ったとき404エラーをレスポンスする() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/employees/100")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                    {
+                                    "employeeNumber": 100,
+                                    "name": "更新後社員",
+                                    "age": 30
+                                    }
+                                """))
+                        .andExpect(status().isNotFound())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                     "message": "EmployeeNumber 100 is not found",
+                     "timestamp": "2024-03-22T19:00:01.451993+09:00[Asia/Tokyo]",
+                     "error": "Not Found",
+                     "path": "/employees/100",
+                     "status": "404"
+                }
+                """, response, new CustomComparator(JSONCompareMode.STRICT,
+                new Customization("timestamp",(((o1, o2) -> true)))));
+    }
+
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @Transactional
+    void 存在する社員情報の名前だけ更新するリクエストを受け取ったとき400エラーをレスポンスする() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/employees/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                    {
+                                    "employeeNumber": 1,
+                                    "name": "更新後社員",
+                                    "age": null
+                                    }
+                                """))
+                        .andExpect(status().isBadRequest())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @Transactional
+    void 存在する社員情報の年齢だけ更新するリクエストを受け取ったとき400エラーをレスポンスする() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/employees/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                    {
+                                    "employeeNumber": 1,
+                                    "name": null,
+                                    "age": 30
+                                    }
+                                """))
+                        .andExpect(status().isBadRequest())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @Transactional
+    void 存在する社員情報の年齢を17歳にしてリクエストを受け取ったとき400エラーをレスポンスする() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/employees/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                    {
+                                    "employeeNumber": 1,
+                                    "name": "更新後社員",
+                                    "age": 17
+                                    }
+                                """))
+                        .andExpect(status().isBadRequest())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @Transactional
+    void 存在する社員情報の年齢を66歳にしてリクエストを受け取ったとき400エラーをレスポンスする() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/employees/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                            {
+                                            "employeeNumber": 1,
+                                            "name": "更新後社員",
+                                            "age": 66
+                                            }
+                                        """))
+                        .andExpect(status().isBadRequest())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+    }
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @Transactional
+    void 存在する社員情報の年齢を18歳にしてリクエストを受け取ったとき400エラーをレスポンスする() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/employees/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                    {
+                                    "employeeNumber": 1,
+                                    "name": "更新後社員",
+                                    "age": 18
+                                    }
+                                """))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @Transactional
+    void 存在する社員情報の年齢を65歳にしてリクエストを受け取ったとき400エラーをレスポンスする() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/employees/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                            {
+                                            "employeeNumber": 1,
+                                            "name": "更新後社員",
+                                            "age": 65
+                                            }
+                                        """))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
     }
 }

--- a/src/test/resources/datasets/insertEmployeeTest.yml
+++ b/src/test/resources/datasets/insertEmployeeTest.yml
@@ -8,6 +8,6 @@ employees:
   - employeeNumber: 3
     name: "ジェフ"
     age: 30
-  - employeeNumber: 3
+  - employeeNumber: 4
     name: "iwatsuki"
     age: 29

--- a/src/test/resources/datasets/updateEmployeeTest.yml
+++ b/src/test/resources/datasets/updateEmployeeTest.yml
@@ -1,0 +1,10 @@
+employees:
+  - employeeNumber: 1
+    name: "ジョブズ"
+    age: 22
+  - employeeNumber: 2
+    name: "マーク"
+    age: 20
+  - employeeNumber: 3
+    name: "ジェフ"
+    age: 30

--- a/src/test/resources/datasets/updateEmployees.yml
+++ b/src/test/resources/datasets/updateEmployees.yml
@@ -1,0 +1,10 @@
+employees:
+  - employeeNumber: 1
+    name: "更新後社員"
+    age: 30
+  - employeeNumber: 2
+    name: "マーク"
+    age: 20
+  - employeeNumber: 3
+    name: "ジェフ"
+    age: 30


### PR DESCRIPTION
# 概要
Update処理のテスト

# 登録できるデータ
18〜６５歳の社員情報

# 実装確認
- Mapper
- [x]　正常系　存在する社員情報を更新するリクエストを受け取ったとき社員情報を更新する
- Service
- [x]　正常系　 存在する社員情報を更新するリクエストを受け取ったとき社員情報を更新する
- [x]　異常系　 存在しない社員情報を更新するリクエストを受け取ったとき404エラーをレスポンスする
- 結合テスト
- [x]　正常系　存在する社員情報を更新するリクエストを受け取ったとき社員情報を更新する
- [x]　異常系　 存在しない社員情報を更新するリクエストを受け取ったとき404エラーをレスポンスする
- [x]　異常系　存在する社員情報の名前だけ更新するリクエストを受け取ったとき400エラーをレスポンスする
- [x]　異常系　存在する社員情報の年齢だけ更新するリクエストを受け取ったとき400エラーをレスポンスする
- [x]　異常系　存在する社員情報の年齢を17歳にしてリクエストを受け取ったとき400エラーをレスポンスする
- [x]　異常系　存在する社員情報の年齢を66歳にしてリクエストを受け取ったとき400エラーをレスポンスする
- [x]　正常系　存在する社員情報の年齢を18歳にしてリクエストを受け取ったとき200をレスポンスする
- [x]　正常系　存在する社員情報の年齢を65歳にしてリクエストを受け取ったとき200をレスポンスする